### PR TITLE
Add return in case of invalid specifier

### DIFF
--- a/get_format.c
+++ b/get_format.c
@@ -23,4 +23,5 @@ int (*get_format(char specifier))(va_list)
 
 		i++;
 	}
+    return (NULL);
 }


### PR DESCRIPTION
get_format could hit the end of the function without a return. Slapped a bandaid on it for now, will fix more soundly later.